### PR TITLE
Updated REPET to 2.5, RepBase to 2017-01-27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV GIRINST_USERNAME AzureDiamond
 ENV GIRINST_PASSWORD hunter2
 
 # Basic REPET requirements
-RUN apt-get update && apt-get install -y apt-utils && apt-get install -y make && apt-get install -y gcc && apt-get install build-essential g++ && apg-get install -y wget && apt-get install -yqq mysql-client ncbi-blast+ python-mysqldb python-yaml
+RUN apt-get update && apt-get install -y apt-utils build-essential wget mysql-client ncbi-blast+ python-mysqldb python-yaml
 
 #ADD REPET
 RUN wget https://urgi.versailles.inra.fr/download/repet/REPET_linux-x64-2.5.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ ENV GIRINST_USERNAME AzureDiamond
 ENV GIRINST_PASSWORD hunter2
 
 # Basic REPET requirements
-RUN apt-get update && apt-get install -yqq mysql-client ncbi-blast+ python-mysqldb python-yaml
+RUN apt-get update && apt-get install -y apt-utils && apt-get install -y make && apt-get install -y gcc && apt-get install build-essential g++ && apg-get install -y wget && apt-get install -yqq mysql-client ncbi-blast+ python-mysqldb python-yaml
 
 #ADD REPET
-RUN wget https://urgi.versailles.inra.fr/download/repet/REPET_linux-x64-2.2.tar.gz \
+RUN wget https://urgi.versailles.inra.fr/download/repet/REPET_linux-x64-2.5.tar.gz \
 && tar --directory / -xvf REPET_linux*.tar.gz \
 && rm REPET_linux*.tar.gz \
 && mv /REPET_linux* /REPET \
@@ -77,9 +77,9 @@ RUN mkdir -p /opt/RepeatMasker \
 
 # Optional Dependencies - Repeatmasker/RepBase
 RUN cd /opt/RepeatMasker/current \
-&& wget http://www.girinst.org/server/RepBase/protected/repeatmaskerlibraries/repeatmaskerlibraries-20150807.tar.gz --password=$GIRINST_PASSWORD  --user=$GIRINST_USERNAME \
-&& tar -xvf repeatmaskerlibraries-*.tar.gz \
-&& rm -rf repeatmaskerlibraries-*.tar.gz
+&& wget http://www.girinst.org/server/RepBase/protected/repeatmaskerlibraries/RepBaseRepeatMaskerEdition-20170127.tar.gz --password=$GIRINST_PASSWORD  --user=$GIRINST_USERNAME \
+&& tar -xvf RepBaseRepeatMaskerEdition-*.tar.gz \
+&& rm -rf RepBaseRepeatMaskerEdition-*.tar.gz
 
 # Optional Dependencies - Repeatmasker/Dfam
 RUN cd /opt/RepeatMasker/current/Libraries \


### PR DESCRIPTION
Still get a bunch of the following errors, but now the image builds:

debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
dpkg-preconfigure: unable to re-open stdin: